### PR TITLE
Upgrade Hapi FHIR Repo version to 5.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 		<spring.version>5.2.4.RELEASE</spring.version>
 		<spotless.version>2.13.0</spotless.version>
 		<servlet.version>2.5</servlet.version>
-		<hapi.fhir.base.version>5.4.0</hapi.fhir.base.version>
+		<hapi.fhir.base.version>5.5.0</hapi.fhir.base.version>
 		<junit.version>4.13.1</junit.version>
 	</properties>
 
@@ -91,7 +91,7 @@
 				</exclusion>
 			</exclusions>
 			<groupId>ca.uhn.hapi.fhir</groupId>
-			<version>5.4.0</version>
+			<version>5.5.0</version>
 		</dependency>
 
 		<!--        Test Dependencies-->


### PR DESCRIPTION
We need to update it to the latest version as Location Hierarchy was breaking due to incompatible versions.
JPA server starter was pointing to 5.5.0 while our extension module was pointing to 5.4.0

- New release was made by the FHIR Team for this quarter
- https://github.com/hapifhir/hapi-fhir/releases/tag/v5.5.0

**For future:**
We need to keep an eye on the latest updates done by the HAPI team to ensure a smooth upgrade to the latest version without breaking our extended code.

cc : @dubdabasoduba  