### PR TITLE
Create new release: Bump up version

### DIFF
--- a/location/pom.xml
+++ b/location/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>hapi-fhir-opensrp-extensions</artifactId>
 		<groupId>org.smartregister</groupId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>0.0.2-SNAPSHOT</version>
 	</parent>
 
 	<description>The repository holds the location extensions on the HAPI server</description>
@@ -12,7 +12,7 @@
 	<name>HAPI FHIR OpenSRP Extensions (Locations)</name>
 	<packaging>jar</packaging>
 	<url>https://github.com/opensrp/hapi-fhir-opensrp-extensions</url>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>0.0.2-SNAPSHOT</version>
 	<artifactId>location</artifactId>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.smartregister</groupId>
 	<artifactId>hapi-fhir-opensrp-extensions</artifactId>
 	<packaging>pom</packaging>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>0.0.2-SNAPSHOT</version>
 	<name>HAPI FHIR OpenSRP Extensions</name>
 	<description>This repository holds all the code extensions on top of Hapi-FHIR</description>
 	<url>https://github.com/opensrp/hapi-fhir-opensrp-extensions</url>


### PR DESCRIPTION
This includes the fix on the Location Heirarchy by updating the HAPI FHIR Library versions.
@dubdabasoduba 