### PR TITLE
Bump up version hapi fhir

### DIFF
--- a/location/pom.xml
+++ b/location/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>hapi-fhir-opensrp-extensions</artifactId>
 		<groupId>org.smartregister</groupId>
-		<version>0.0.3-SNAPSHOT</version>
+		<version>0.0.4-SNAPSHOT</version>
 	</parent>
 
 	<description>The repository holds the location extensions on the HAPI server</description>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 		<spring.version>5.2.4.RELEASE</spring.version>
 		<spotless.version>2.13.0</spotless.version>
 		<servlet.version>2.5</servlet.version>
-		<hapi.fhir.base.version>5.7.0-PRE7-SNAPSHOT</hapi.fhir.base.version>
+		<hapi.fhir.base.version>5.7.0-PRE8-SNAPSHOT</hapi.fhir.base.version>
 		<junit.version>4.13.1</junit.version>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.smartregister</groupId>
 	<artifactId>hapi-fhir-opensrp-extensions</artifactId>
 	<packaging>pom</packaging>
-	<version>0.0.3-SNAPSHOT</version>
+	<version>0.0.4-SNAPSHOT</version>
 	<name>HAPI FHIR OpenSRP Extensions</name>
 	<description>This repository holds all the code extensions on top of Hapi-FHIR</description>
 	<url>https://github.com/opensrp/hapi-fhir-opensrp-extensions</url>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 		<spring.version>5.2.4.RELEASE</spring.version>
 		<spotless.version>2.13.0</spotless.version>
 		<servlet.version>2.5</servlet.version>
-		<hapi.fhir.base.version>5.5.0</hapi.fhir.base.version>
+		<hapi.fhir.base.version>5.7.0-PRE7-SNAPSHOT</hapi.fhir.base.version>
 		<junit.version>4.13.1</junit.version>
 	</properties>
 


### PR DESCRIPTION
https://github.com/opensrp/opensrp-server-web/issues/1028 
This PR contains a fix to mitigate log4j vulnerability by updating hapi-fhir dependencies.
cc : @f-odhiambo  @dubdabasoduba 